### PR TITLE
Updated to 1.31.1 upstream docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kingsquare/mediawiki:1.30.0
+FROM kingsquare/mediawiki:1.31.1
 
 # install redis php module
 # update upstream composer


### PR DESCRIPTION
Note before publication depends on `mediawiki-docker` being published